### PR TITLE
Implemented lazy loading of pdf

### DIFF
--- a/frontend/src/logic/pdfFunctions.js
+++ b/frontend/src/logic/pdfFunctions.js
@@ -14,11 +14,15 @@ export const pdfToBinaryString = file => {
   })
 }
 
-export const pdfBinaryToImages = async data => {
+export const pdfBinaryToImages = async (data, processNow, store) => {
   let imgArr = []
   let doc = await getDocument({ data }).promise
 
-  for (let i = 1; i <= doc.numPages; i++) {
+  let now = doc.numPages
+
+  if (doc.numPages > processNow) now = processNow
+
+  for (let i = 1; i <= now; i++) {
     let page = await doc.getPage(i)
 
     // Using greater scale gives better quality (when zooming in/out)
@@ -33,5 +37,8 @@ export const pdfBinaryToImages = async data => {
     await task.promise
     imgArr.push(canvas.toDataURL())
   }
+
+  if (doc.numPages > processNow) store.dispatch('lazyLoadPDF', { doc, now })
+
   return imgArr
 }

--- a/frontend/src/pages/Home.vue
+++ b/frontend/src/pages/Home.vue
@@ -20,7 +20,7 @@ const openFileInput = () => {
 const processFile = async e => {
   if (e.target.files.length === 0) return
   let pdfBinary = await pdfToBinaryString(e.target.files[0])
-  let imgArr = await pdfBinaryToImages(pdfBinary)
+  let imgArr = await pdfBinaryToImages(pdfBinary, 5, store)
   store.commit('setImageSources', imgArr)
   router.push('/preprocess')
 }

--- a/frontend/src/store/actions.js
+++ b/frontend/src/store/actions.js
@@ -1,0 +1,25 @@
+// Called if the PDF has more than 5 pages
+// Loads PDF pages past 5 in the background while showing the first 5
+
+const lazyLoadPDF = (store, { doc, now }) => {
+  for (let i = now + 1; i <= doc.numPages; i++) {
+    doc.getPage(i).then(page => {
+      let viewport = page.getViewport({ scale: 4 })
+      let canvas = document.createElement('canvas')
+      canvas.width = viewport.width
+      canvas.height = viewport.height
+      let canvasContext = canvas.getContext('2d')
+      let task = page.render({ canvasContext, viewport })
+      task.promise.then(() => {
+        store.commit('setImageSources', [
+          ...store.state.imageSources,
+          canvas.toDataURL()
+        ])
+      })
+    })
+  }
+}
+
+export default {
+  lazyLoadPDF
+}

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -1,5 +1,6 @@
 import { createStore } from 'vuex'
-import mutations from './mutations'
+import mutations from '@/store/mutations'
+import actions from '@/store/actions'
 
 export const store = createStore({
   state() {
@@ -11,5 +12,6 @@ export const store = createStore({
       zoom: 1
     }
   },
-  mutations
+  mutations,
+  actions
 })


### PR DESCRIPTION
1) For large PDFs (> 5 pages), first 5 pages are loaded synchronously.
2) Remaining pages are loaded in the background while showing the first 5.
3) Since large PDFs have very high processing time, this improves UX.